### PR TITLE
restore niftyreg to requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - magicgui
     - napari-plugin-engine >=0.1.4
     - napari
+    - niftyreg
     - pyqt
     - pandas
     - scipy


### PR DESCRIPTION
Looks like we lost `niftyreg` from our requirements in https://github.com/conda-forge/brainreg-feedstock/commit/d727715d7e4761e65977f8ff082a15df2a54d6ad.

Restoring it should at least partially fix https://github.com/brainglobe/brainreg/issues/206